### PR TITLE
Add dev dependencies to pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dev = [
 ]
 
 [project.optional-dependencies]
+dev = ["pytest", "jupyter", "matplotlib", "pandas", "scikit-learn"]
 qiskit = ["qiskit>=1.0.2"]
 pennylane = ["pennylane>=0.35.1", "openqasm3[parser]"]
 examples = ["qiskit>=1.0.2", "pennylane>=0.35.1", "openqasm3[parser]", "qutip"]


### PR DESCRIPTION
They were specified only for the pdm tool