### PR TITLE
Sparse data upload with API & version look-up for processing steps.

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev", "examples", "qiskit"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:e2a9eb1353c4e7477c35f7668760b4b8fd5a487e7bb725e98527ee944383a51c"
+content_hash = "sha256:ce56031efa781976da225d974e271186153a7ab057375703f3df6e21d97eca43"
 
 [[metadata.targets]]
 requires_python = "~=3.11"
@@ -1338,7 +1338,7 @@ files = [
 
 [[package]]
 name = "matplotlib"
-version = "3.10.0"
+version = "3.10.1"
 requires_python = ">=3.10"
 summary = "Python plotting package"
 groups = ["dev", "examples"]
@@ -1354,31 +1354,31 @@ dependencies = [
     "python-dateutil>=2.7",
 ]
 files = [
-    {file = "matplotlib-3.10.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:fd44fc75522f58612ec4a33958a7e5552562b7705b42ef1b4f8c0818e304a363"},
-    {file = "matplotlib-3.10.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c58a9622d5dbeb668f407f35f4e6bfac34bb9ecdcc81680c04d0258169747997"},
-    {file = "matplotlib-3.10.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:845d96568ec873be63f25fa80e9e7fae4be854a66a7e2f0c8ccc99e94a8bd4ef"},
-    {file = "matplotlib-3.10.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5439f4c5a3e2e8eab18e2f8c3ef929772fd5641876db71f08127eed95ab64683"},
-    {file = "matplotlib-3.10.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:4673ff67a36152c48ddeaf1135e74ce0d4bce1bbf836ae40ed39c29edf7e2765"},
-    {file = "matplotlib-3.10.0-cp311-cp311-win_amd64.whl", hash = "sha256:7e8632baebb058555ac0cde75db885c61f1212e47723d63921879806b40bec6a"},
-    {file = "matplotlib-3.10.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4659665bc7c9b58f8c00317c3c2a299f7f258eeae5a5d56b4c64226fca2f7c59"},
-    {file = "matplotlib-3.10.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d44cb942af1693cced2604c33a9abcef6205601c445f6d0dc531d813af8a2f5a"},
-    {file = "matplotlib-3.10.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a994f29e968ca002b50982b27168addfd65f0105610b6be7fa515ca4b5307c95"},
-    {file = "matplotlib-3.10.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9b0558bae37f154fffda54d779a592bc97ca8b4701f1c710055b609a3bac44c8"},
-    {file = "matplotlib-3.10.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:503feb23bd8c8acc75541548a1d709c059b7184cde26314896e10a9f14df5f12"},
-    {file = "matplotlib-3.10.0-cp312-cp312-win_amd64.whl", hash = "sha256:c40ba2eb08b3f5de88152c2333c58cee7edcead0a2a0d60fcafa116b17117adc"},
-    {file = "matplotlib-3.10.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:96f2886f5c1e466f21cc41b70c5a0cd47bfa0015eb2d5793c88ebce658600e25"},
-    {file = "matplotlib-3.10.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:12eaf48463b472c3c0f8dbacdbf906e573013df81a0ab82f0616ea4b11281908"},
-    {file = "matplotlib-3.10.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2fbbabc82fde51391c4da5006f965e36d86d95f6ee83fb594b279564a4c5d0d2"},
-    {file = "matplotlib-3.10.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ad2e15300530c1a94c63cfa546e3b7864bd18ea2901317bae8bbf06a5ade6dcf"},
-    {file = "matplotlib-3.10.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:3547d153d70233a8496859097ef0312212e2689cdf8d7ed764441c77604095ae"},
-    {file = "matplotlib-3.10.0-cp313-cp313-win_amd64.whl", hash = "sha256:c55b20591ced744aa04e8c3e4b7543ea4d650b6c3c4b208c08a05b4010e8b442"},
-    {file = "matplotlib-3.10.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:9ade1003376731a971e398cc4ef38bb83ee8caf0aee46ac6daa4b0506db1fd06"},
-    {file = "matplotlib-3.10.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:95b710fea129c76d30be72c3b38f330269363fbc6e570a5dd43580487380b5ff"},
-    {file = "matplotlib-3.10.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5cdbaf909887373c3e094b0318d7ff230b2ad9dcb64da7ade654182872ab2593"},
-    {file = "matplotlib-3.10.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d907fddb39f923d011875452ff1eca29a9e7f21722b873e90db32e5d8ddff12e"},
-    {file = "matplotlib-3.10.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:3b427392354d10975c1d0f4ee18aa5844640b512d5311ef32efd4dd7db106ede"},
-    {file = "matplotlib-3.10.0-cp313-cp313t-win_amd64.whl", hash = "sha256:5fd41b0ec7ee45cd960a8e71aea7c946a28a0b8a4dcee47d2856b2af051f334c"},
-    {file = "matplotlib-3.10.0.tar.gz", hash = "sha256:b886d02a581b96704c9d1ffe55709e49b4d2d52709ccebc4be42db856e511278"},
+    {file = "matplotlib-3.10.1-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:057206ff2d6ab82ff3e94ebd94463d084760ca682ed5f150817b859372ec4401"},
+    {file = "matplotlib-3.10.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a144867dd6bf8ba8cb5fc81a158b645037e11b3e5cf8a50bd5f9917cb863adfe"},
+    {file = "matplotlib-3.10.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:56c5d9fcd9879aa8040f196a235e2dcbdf7dd03ab5b07c0696f80bc6cf04bedd"},
+    {file = "matplotlib-3.10.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0f69dc9713e4ad2fb21a1c30e37bd445d496524257dfda40ff4a8efb3604ab5c"},
+    {file = "matplotlib-3.10.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:4c59af3e8aca75d7744b68e8e78a669e91ccbcf1ac35d0102a7b1b46883f1dd7"},
+    {file = "matplotlib-3.10.1-cp311-cp311-win_amd64.whl", hash = "sha256:11b65088c6f3dae784bc72e8d039a2580186285f87448babb9ddb2ad0082993a"},
+    {file = "matplotlib-3.10.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:66e907a06e68cb6cfd652c193311d61a12b54f56809cafbed9736ce5ad92f107"},
+    {file = "matplotlib-3.10.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:e9b4bb156abb8fa5e5b2b460196f7db7264fc6d62678c03457979e7d5254b7be"},
+    {file = "matplotlib-3.10.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1985ad3d97f51307a2cbfc801a930f120def19ba22864182dacef55277102ba6"},
+    {file = "matplotlib-3.10.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c96f2c2f825d1257e437a1482c5a2cf4fee15db4261bd6fc0750f81ba2b4ba3d"},
+    {file = "matplotlib-3.10.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:35e87384ee9e488d8dd5a2dd7baf471178d38b90618d8ea147aced4ab59c9bea"},
+    {file = "matplotlib-3.10.1-cp312-cp312-win_amd64.whl", hash = "sha256:cfd414bce89cc78a7e1d25202e979b3f1af799e416010a20ab2b5ebb3a02425c"},
+    {file = "matplotlib-3.10.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c42eee41e1b60fd83ee3292ed83a97a5f2a8239b10c26715d8a6172226988d7b"},
+    {file = "matplotlib-3.10.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4f0647b17b667ae745c13721602b540f7aadb2a32c5b96e924cd4fea5dcb90f1"},
+    {file = "matplotlib-3.10.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:aa3854b5f9473564ef40a41bc922be978fab217776e9ae1545c9b3a5cf2092a3"},
+    {file = "matplotlib-3.10.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7e496c01441be4c7d5f96d4e40f7fca06e20dcb40e44c8daa2e740e1757ad9e6"},
+    {file = "matplotlib-3.10.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5d45d3f5245be5b469843450617dcad9af75ca50568acf59997bed9311131a0b"},
+    {file = "matplotlib-3.10.1-cp313-cp313-win_amd64.whl", hash = "sha256:8e8e25b1209161d20dfe93037c8a7f7ca796ec9aa326e6e4588d8c4a5dd1e473"},
+    {file = "matplotlib-3.10.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:19b06241ad89c3ae9469e07d77efa87041eac65d78df4fcf9cac318028009b01"},
+    {file = "matplotlib-3.10.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:01e63101ebb3014e6e9f80d9cf9ee361a8599ddca2c3e166c563628b39305dbb"},
+    {file = "matplotlib-3.10.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3f06bad951eea6422ac4e8bdebcf3a70c59ea0a03338c5d2b109f57b64eb3972"},
+    {file = "matplotlib-3.10.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a3dfb036f34873b46978f55e240cff7a239f6c4409eac62d8145bad3fc6ba5a3"},
+    {file = "matplotlib-3.10.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:dc6ab14a7ab3b4d813b88ba957fc05c79493a037f54e246162033591e770de6f"},
+    {file = "matplotlib-3.10.1-cp313-cp313t-win_amd64.whl", hash = "sha256:bc411ebd5889a78dabbc457b3fa153203e22248bfa6eedc6797be5df0164dbf9"},
+    {file = "matplotlib-3.10.1.tar.gz", hash = "sha256:e8d2d0e3881b129268585bf4765ad3ee73a4591d77b9a18c214ac7e3a79fb2ba"},
 ]
 
 [[package]]
@@ -1912,6 +1912,43 @@ files = [
 ]
 
 [[package]]
+name = "pyarrow"
+version = "19.0.1"
+requires_python = ">=3.9"
+summary = "Python library for Apache Arrow"
+groups = ["default"]
+files = [
+    {file = "pyarrow-19.0.1-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:cc55d71898ea30dc95900297d191377caba257612f384207fe9f8293b5850f90"},
+    {file = "pyarrow-19.0.1-cp311-cp311-macosx_12_0_x86_64.whl", hash = "sha256:7a544ec12de66769612b2d6988c36adc96fb9767ecc8ee0a4d270b10b1c51e00"},
+    {file = "pyarrow-19.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0148bb4fc158bfbc3d6dfe5001d93ebeed253793fff4435167f6ce1dc4bddeae"},
+    {file = "pyarrow-19.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f24faab6ed18f216a37870d8c5623f9c044566d75ec586ef884e13a02a9d62c5"},
+    {file = "pyarrow-19.0.1-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:4982f8e2b7afd6dae8608d70ba5bd91699077323f812a0448d8b7abdff6cb5d3"},
+    {file = "pyarrow-19.0.1-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:49a3aecb62c1be1d822f8bf629226d4a96418228a42f5b40835c1f10d42e4db6"},
+    {file = "pyarrow-19.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:008a4009efdb4ea3d2e18f05cd31f9d43c388aad29c636112c2966605ba33466"},
+    {file = "pyarrow-19.0.1-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:80b2ad2b193e7d19e81008a96e313fbd53157945c7be9ac65f44f8937a55427b"},
+    {file = "pyarrow-19.0.1-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:ee8dec072569f43835932a3b10c55973593abc00936c202707a4ad06af7cb294"},
+    {file = "pyarrow-19.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4d5d1ec7ec5324b98887bdc006f4d2ce534e10e60f7ad995e7875ffa0ff9cb14"},
+    {file = "pyarrow-19.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f3ad4c0eb4e2a9aeb990af6c09e6fa0b195c8c0e7b272ecc8d4d2b6574809d34"},
+    {file = "pyarrow-19.0.1-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:d383591f3dcbe545f6cc62daaef9c7cdfe0dff0fb9e1c8121101cabe9098cfa6"},
+    {file = "pyarrow-19.0.1-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:b4c4156a625f1e35d6c0b2132635a237708944eb41df5fbe7d50f20d20c17832"},
+    {file = "pyarrow-19.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:5bd1618ae5e5476b7654c7b55a6364ae87686d4724538c24185bbb2952679960"},
+    {file = "pyarrow-19.0.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:e45274b20e524ae5c39d7fc1ca2aa923aab494776d2d4b316b49ec7572ca324c"},
+    {file = "pyarrow-19.0.1-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:d9dedeaf19097a143ed6da37f04f4051aba353c95ef507764d344229b2b740ae"},
+    {file = "pyarrow-19.0.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6ebfb5171bb5f4a52319344ebbbecc731af3f021e49318c74f33d520d31ae0c4"},
+    {file = "pyarrow-19.0.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f2a21d39fbdb948857f67eacb5bbaaf36802de044ec36fbef7a1c8f0dd3a4ab2"},
+    {file = "pyarrow-19.0.1-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:99bc1bec6d234359743b01e70d4310d0ab240c3d6b0da7e2a93663b0158616f6"},
+    {file = "pyarrow-19.0.1-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:1b93ef2c93e77c442c979b0d596af45e4665d8b96da598db145b0fec014b9136"},
+    {file = "pyarrow-19.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:d9d46e06846a41ba906ab25302cf0fd522f81aa2a85a71021826f34639ad31ef"},
+    {file = "pyarrow-19.0.1-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:c0fe3dbbf054a00d1f162fda94ce236a899ca01123a798c561ba307ca38af5f0"},
+    {file = "pyarrow-19.0.1-cp313-cp313t-macosx_12_0_x86_64.whl", hash = "sha256:96606c3ba57944d128e8a8399da4812f56c7f61de8c647e3470b417f795d0ef9"},
+    {file = "pyarrow-19.0.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8f04d49a6b64cf24719c080b3c2029a3a5b16417fd5fd7c4041f94233af732f3"},
+    {file = "pyarrow-19.0.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5a9137cf7e1640dce4c190551ee69d478f7121b5c6f323553b319cac936395f6"},
+    {file = "pyarrow-19.0.1-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:7c1bca1897c28013db5e4c83944a2ab53231f541b9e0c3f4791206d0c0de389a"},
+    {file = "pyarrow-19.0.1-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:58d9397b2e273ef76264b45531e9d552d8ec8a6688b7390b5be44c02a37aade8"},
+    {file = "pyarrow-19.0.1.tar.gz", hash = "sha256:3bf266b485df66a400f282ac0b6d1b500b9d2ae73314a153dbe97d6d5cc8a99e"},
+]
+
+[[package]]
 name = "pycparser"
 version = "2.22"
 requires_python = ">=3.8"
@@ -2047,7 +2084,7 @@ files = [
 
 [[package]]
 name = "pytest"
-version = "8.3.4"
+version = "8.3.5"
 requires_python = ">=3.8"
 summary = "pytest: simple powerful testing with Python"
 groups = ["dev"]
@@ -2060,8 +2097,8 @@ dependencies = [
     "tomli>=1; python_version < \"3.11\"",
 ]
 files = [
-    {file = "pytest-8.3.4-py3-none-any.whl", hash = "sha256:50e16d954148559c9a74109af1eaf0c945ba2d8f30f0a3d3335edde19788b6f6"},
-    {file = "pytest-8.3.4.tar.gz", hash = "sha256:965370d062bce11e73868e0335abac31b4d3de0e82f4007408d242b4f8610761"},
+    {file = "pytest-8.3.5-py3-none-any.whl", hash = "sha256:c69214aa47deac29fad6c2a4f590b9c4a9fdb16a403176fe154b79c0b4d4d820"},
+    {file = "pytest-8.3.5.tar.gz", hash = "sha256:f4efe70cc14e511565ac476b57c279e12a855b11f48f212af1080ef2263d3845"},
 ]
 
 [[package]]
@@ -2232,7 +2269,7 @@ files = [
 
 [[package]]
 name = "qiskit"
-version = "1.3.2"
+version = "1.4.2"
 requires_python = ">=3.9"
 summary = "An open-source SDK for working with quantum computers at the level of extended quantum circuits, operators, and primitives."
 groups = ["examples", "qiskit"]
@@ -2248,21 +2285,21 @@ dependencies = [
     "typing-extensions",
 ]
 files = [
-    {file = "qiskit-1.3.2-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:3fe16377787e31c67b87b2baa9fe3239ffab46e1697ed7dfc4687f89f283453b"},
-    {file = "qiskit-1.3.2-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:fc7be685e0f144825201da4c818e370977ab1be07049587899b209beca48a39e"},
-    {file = "qiskit-1.3.2-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2f5a91c0f3f90cd1716aa99357965e4011f6f9fa37636c706a8829f7f408384b"},
-    {file = "qiskit-1.3.2-cp39-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:65d5af561b6e0e98b099fe4b7bf099dcd1f09322fa1d47299ba2b2febc873ec7"},
-    {file = "qiskit-1.3.2-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a24090a779bf8153a99d3d8d56fe161ccfd57ef96ab55d4320b3f376320ad1ce"},
-    {file = "qiskit-1.3.2-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:253fa4d8b27c9dd1462fe67fec7428c2a3784216aa06babbb1a47547fa2afe8f"},
-    {file = "qiskit-1.3.2-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:309f6db004ea8044df9ac9359c31dcce0cc12afb6ece6eb035ca86b9bf87a21c"},
-    {file = "qiskit-1.3.2-cp39-abi3-win32.whl", hash = "sha256:113a6962b3cd79a0aeeee92072a3e808291e776d8ca7ab25dffaea2e0c288b8d"},
-    {file = "qiskit-1.3.2-cp39-abi3-win_amd64.whl", hash = "sha256:8ec122c81f832c1a9202dae6485d402d1444845be2c53809f10d82cb1423e735"},
-    {file = "qiskit-1.3.2.tar.gz", hash = "sha256:6e63c619bcc3e29cd59f831af5b161b35951498c272d00da01a3fef7db3743c9"},
+    {file = "qiskit-1.4.2-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:310d0fa8a3fbb8f6f0e09ba61602e28cf49d084f2b28a20fc965ee966ed79e4e"},
+    {file = "qiskit-1.4.2-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:e079f49557b46e7bef42294477aa16d790d16d4feb6841ed440022e8055ea128"},
+    {file = "qiskit-1.4.2-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7ba0788b71614a37f8a886563a5122756a50c4bfd40951b54a0083424891d47b"},
+    {file = "qiskit-1.4.2-cp39-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4c2ec657c6387e6b32ac950e94ebaed7e897208cd2af42fec00b9c724d997145"},
+    {file = "qiskit-1.4.2-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ced4c2229bcf5c47f83f9a5003a97ad5fb69bbb2e7cc9b93ac8b9d2023e79c85"},
+    {file = "qiskit-1.4.2-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d7b8e6850d806ab56316e64292b099885677ffc0ccdde3c3aafd48096cbb620a"},
+    {file = "qiskit-1.4.2-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8ca3a5b7b7b8079d91daafa60f5f1283cc0dfddc86a78e8fbcd47efbebbfd5ad"},
+    {file = "qiskit-1.4.2-cp39-abi3-win32.whl", hash = "sha256:57c4922863d50109da28ba5de0fc720c16c8b47ed20c69fe51cfa9919d1d22b2"},
+    {file = "qiskit-1.4.2-cp39-abi3-win_amd64.whl", hash = "sha256:4d8043ac40302470fd9c275091a4cd11fd70108f4b70e89fe2764da6281299e1"},
+    {file = "qiskit-1.4.2.tar.gz", hash = "sha256:3cc75cd39d524dfff695d72c7589dfaf945d112ab9e4d4e6a4c06d6ffd439d2f"},
 ]
 
 [[package]]
 name = "qiskit-aer"
-version = "0.16.1"
+version = "0.17.0"
 requires_python = ">=3.7"
 summary = "Aer - High performance simulators for Qiskit"
 groups = ["examples"]
@@ -2273,32 +2310,35 @@ dependencies = [
     "scipy>=1.0",
 ]
 files = [
-    {file = "qiskit_aer-0.16.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:a16c1ac16d129cffb4188147c1327a58119161f592bc44f4e5f74bacefe6dc4e"},
-    {file = "qiskit_aer-0.16.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:cb77963775c70d29c4772275e485bf947f95f63ce30edbe09e3467600bae0752"},
-    {file = "qiskit_aer-0.16.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4a896064100f0d88720af42bfc903bf26110f4eab9f84deff7269e1dabfba1f6"},
-    {file = "qiskit_aer-0.16.1-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b8e48505e64f29a913088a966935567429f115cf9ef91a58c2ea72beca286982"},
-    {file = "qiskit_aer-0.16.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:80b7c02c3d6fd48e6efa22b76c8599860bcc284eda2e74ab286abf60a1603e76"},
-    {file = "qiskit_aer-0.16.1-cp311-cp311-win32.whl", hash = "sha256:b1c18c151d87385a702459e92fd19f4d1f0c95e582ee6519d070ca8231650d2b"},
-    {file = "qiskit_aer-0.16.1-cp311-cp311-win_amd64.whl", hash = "sha256:966097010edf1e77f605d06100cabb013396c1f2c1f6d457f55334fb3b2cdfd9"},
-    {file = "qiskit_aer-0.16.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8783c200170789f6804ce323d696febe80293ed6dd9f748211803dbcab743aff"},
-    {file = "qiskit_aer-0.16.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1d0d1eb71c7e276af4e7a4f98cd416559e34b3d3103a0d459c2c6a94bff42179"},
-    {file = "qiskit_aer-0.16.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d6fd5a5692ac0efbb63885dca9c30ade2dc7da739f513a19ca2fbef84a366eb8"},
-    {file = "qiskit_aer-0.16.1-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4d0c853b226664238aafb57f0111aa795e42732dcf1ca973b48a7cd0bb317596"},
-    {file = "qiskit_aer-0.16.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ffa2f27730ed2dd471ed73ade8f97a90c1b6f681f3d5a8e4d0c51dce855b353d"},
-    {file = "qiskit_aer-0.16.1-cp312-cp312-win32.whl", hash = "sha256:ccc325acd4daa302293dab950850f5d6ff00404c24e47aed4134967e472c31c2"},
-    {file = "qiskit_aer-0.16.1-cp312-cp312-win_amd64.whl", hash = "sha256:de1709d99a800b99e9fa0f49a6990cce7bdb6ce32bf1655049487b7754646196"},
-    {file = "qiskit_aer-0.16.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:881f79961d77ce101f6d2c18ed5b2f070ce63e6b01ee9b36b96bf2dc66acfe1b"},
-    {file = "qiskit_aer-0.16.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:86ea3c09fa14dbffafac29265ff161c89d0c72616822ec8c117012801fd76cff"},
-    {file = "qiskit_aer-0.16.1-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2d94b87a7c0753826d0f0376d7dd7377ee2cc45994b4b88dd2f1747c8a0aa99a"},
-    {file = "qiskit_aer-0.16.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:301098b862d33f8176421d173d6903e22ec2339b0b1919c980e4f55aa7874298"},
-    {file = "qiskit_aer-0.16.1-cp313-cp313-win32.whl", hash = "sha256:b9eb2251fd855696fbb2e733a3a2bf50b058e71b97588ca24e4242acac1dc39f"},
-    {file = "qiskit_aer-0.16.1-cp313-cp313-win_amd64.whl", hash = "sha256:9f893c633513f1f0c9137ba5f642ee7e2ab38513e25c06b0967f5499871ff6a6"},
-    {file = "qiskit_aer-0.16.1.tar.gz", hash = "sha256:cf58dd8b32d86fc78153ebd5eebdd2ffe8a40b07105cf321b49375b0ccbd6275"},
+    {file = "qiskit_aer-0.17.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:e0d34d1ca2272351cdf5f0d49da7649a98736a59d5f36523ddc66cfb4739de4a"},
+    {file = "qiskit_aer-0.17.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:5b3ba68b4c7432aab65796c23fbb82bcccfd3bf7a979bc16193db5d6ff48b10c"},
+    {file = "qiskit_aer-0.17.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:13455198a5928e38e3c9844976a91c24f88726126e257a44d0027b0d9c0402e1"},
+    {file = "qiskit_aer-0.17.0-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:79ec8397b9cd1f4d2f29a16dcec1853875f399704f98b76dcf6cef3464480807"},
+    {file = "qiskit_aer-0.17.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:06e938a0347401c8bfd3c3229a7c88a1a97f7db182480726a267db391ca69077"},
+    {file = "qiskit_aer-0.17.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7c64d8fd639362cd50a53baa3500045b936add3905bdb8e678db3ef7e644001e"},
+    {file = "qiskit_aer-0.17.0-cp311-cp311-win32.whl", hash = "sha256:d812a5d58e039cbd738ebfe0315f7e9a475c270d8c962117920b6c3d731f71ba"},
+    {file = "qiskit_aer-0.17.0-cp311-cp311-win_amd64.whl", hash = "sha256:1b10e3dbdf1bdaaed8477d1140da160bbfbaa1313ff05400b7f6e4ec36773c49"},
+    {file = "qiskit_aer-0.17.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:83affcb117e2182ea193d46d735aa9bd73778346b87e9cfe8ba865ce350d4c3d"},
+    {file = "qiskit_aer-0.17.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4e3936e25833f42b431740ef494cc4502dc32f5aabb0f7305e98695d26104ade"},
+    {file = "qiskit_aer-0.17.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8fea4d0733eeb32c89593a521d3d8ad705d76e6d16351e1e5066561aa64c6c41"},
+    {file = "qiskit_aer-0.17.0-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ed17455b4c5523c49ee923fabdcb0e28137000fc470070e000d4b3216846f5c5"},
+    {file = "qiskit_aer-0.17.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:755284fd026c5eefdde716ec47a67ce862b11661a378b8a0867e96d0639fa991"},
+    {file = "qiskit_aer-0.17.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c4b54281e309ac9a8c7446149c29581195aac39f92e36bd7f9ad236b3a874b2"},
+    {file = "qiskit_aer-0.17.0-cp312-cp312-win32.whl", hash = "sha256:fb73909ae556efc29cb4ccf4004a519b61e1d09126bc7571675f927627deb80c"},
+    {file = "qiskit_aer-0.17.0-cp312-cp312-win_amd64.whl", hash = "sha256:bfeafcb76fb864bfafd9d5dc1c90b3bf64b6918ff8d83466f516dc6e004f7f1f"},
+    {file = "qiskit_aer-0.17.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c8e4a25da10718535e3a856b0d9667c349e95bb0bdd9627e2cf6955de1186494"},
+    {file = "qiskit_aer-0.17.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4658878ca93d2d3b3d3bf051f482a76407e69a4a8a4de2087f0edf7b72df8fef"},
+    {file = "qiskit_aer-0.17.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e64606aacb61e776f5416afa987a79514666fa5447916c0e6d6dc6d5bf522ff4"},
+    {file = "qiskit_aer-0.17.0-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cf3ffc81f9b66b9279c28a53762d6ae51cd97a40ec53853c7e9b05ba13c1cc4f"},
+    {file = "qiskit_aer-0.17.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4e755a1eb0ed887eba4122193deadc050e7b6e9a6df3f00a25adaca34099286e"},
+    {file = "qiskit_aer-0.17.0-cp313-cp313-win32.whl", hash = "sha256:cf2f64421d74a54d3c2887bdaa86105006c3a08b59bd68e5d3f73a43ebc667dd"},
+    {file = "qiskit_aer-0.17.0-cp313-cp313-win_amd64.whl", hash = "sha256:569b1a69f2ccd55e79dfb450a808334985c32c8f43b6728aad0b134a43c657e3"},
+    {file = "qiskit_aer-0.17.0.tar.gz", hash = "sha256:8e17c6a10cea5ebcb0316b71ac2afaf4f2fb26ca2f124d9122f3bf1cf68d095c"},
 ]
 
 [[package]]
 name = "qiskit-experiments"
-version = "0.8.1"
+version = "0.8.2"
 requires_python = ">=3.9"
 summary = "Software for developing quantum computing programs"
 groups = ["examples"]
@@ -2316,8 +2356,8 @@ dependencies = [
     "uncertainties",
 ]
 files = [
-    {file = "qiskit-experiments-0.8.1.tar.gz", hash = "sha256:0b1f4bf844947e58757f0bd3f0dcfccab90634480fd676d0a30851707350f20e"},
-    {file = "qiskit_experiments-0.8.1-py3-none-any.whl", hash = "sha256:3cbd49cf2fe10d986fb78b56ac330fc1dffbfd339859219f72cf98c3dafe2ff9"},
+    {file = "qiskit-experiments-0.8.2.tar.gz", hash = "sha256:f9e03f2fc42dfc8fa667f4b8b5ed3b5b1e98935f59069d201f3388b54cda483c"},
+    {file = "qiskit_experiments-0.8.2-py3-none-any.whl", hash = "sha256:b342a2f04fbd61778d570f4469ecf2b2a4d5995d6c491e3d2763d6b25c65d1ef"},
 ]
 
 [[package]]

--- a/pdm.lock
+++ b/pdm.lock
@@ -1814,7 +1814,7 @@ files = [
 
 [[package]]
 name = "pinexq-client"
-version = "0.9.1.20241213.2"
+version = "0.9.2.20250317.3"
 requires_python = ">=3.11"
 summary = "A hypermedia-based client for the DataCybernetics PinexQ platform."
 groups = ["default"]
@@ -1823,7 +1823,7 @@ dependencies = [
     "pydantic<3.0.0,>=2.1.0",
 ]
 files = [
-    {file = "pinexq_client-0.9.1.20241213.2-py3-none-any.whl", hash = "sha256:6d9919e694d062a41abe0b5d8895b2a305fe4b7a41ead666c6417bd8260215ce"},
+    {file = "pinexq_client-0.9.2.20250317.3-py3-none-any.whl", hash = "sha256:e002db378c966fe4bc5f57ac2457e38d512ed307b6d77217b07308feaa716cad"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,8 @@ dependencies = [
     "httpx<1.0.0,>=0.25.0",
     "tenacity>=8.2.3",
     "pinexq-client>=0.3.0.20240620.2",
-    "tqdm"
+    "tqdm",
+    "pyarrow>=19.0.1"
 ]
 requires-python = "<4,>=3.11"
 readme = "README.md"

--- a/src/q_alchemy/initialize.py
+++ b/src/q_alchemy/initialize.py
@@ -235,6 +235,7 @@ def q_alchemy_as_qasm_parallel_states(
     threads = []
     job_list = []
     for vec in state_vector:
+        vec = convert_sparse_coo_to_arrow(sparse.coo_matrix(vec).reshape(1, -1))
         def func(_vec):
             statevector_link = upload_statevector(client, _vec, opt_params)
             job = configure_job(client, statevector_link, opt_params)

--- a/src/q_alchemy/initialize.py
+++ b/src/q_alchemy/initialize.py
@@ -181,7 +181,10 @@ def q_alchemy_as_qasm(state_vector: List[complex] | np.ndarray | sparse.coo_arra
     client = client if client is not None else create_client(opt_params)
 
     # The state vector need to be converted to a (1, 2**n) sparse (COO) matrix
-    data_matrix: sparse.coo_matrix = sparse.coo_matrix(state_vector).reshape(1, -1)
+    if isinstance(state_vector, sparse.coo_array):
+        data_matrix: sparse.coo_matrix = sparse.coo_matrix(state_vector.reshape(1, -1)).reshape(1, -1)
+    else:
+        data_matrix: sparse.coo_matrix = sparse.coo_matrix(state_vector).reshape(1, -1)
     data_matrix_pyarrow: pa.Table = convert_sparse_coo_to_arrow(data_matrix)
     statevector_link = upload_statevector(client, data_matrix_pyarrow, opt_params)
 

--- a/src/q_alchemy/initialize.py
+++ b/src/q_alchemy/initialize.py
@@ -174,7 +174,7 @@ def clean_up_job(job: Job, opt_params: OptParams) -> None:
         job.refresh().delete()
 
 
-def q_alchemy_as_qasm(state_vector: List[complex] | np.ndarray | sparse.coo_array, opt_params: dict | OptParams | None = None,
+def q_alchemy_as_qasm(state_vector: List[complex] | np.ndarray | sparse.coo_array | sparse.coo_matrix, opt_params: dict | OptParams | None = None,
                       client: httpx.Client | None = None, return_summary=False,  **kwargs) -> str | Tuple[str, dict]:
 
     opt_params: OptParams = populate_opt_params(opt_params, **kwargs)

--- a/src/q_alchemy/initialize.py
+++ b/src/q_alchemy/initialize.py
@@ -98,7 +98,7 @@ def upload_statevector(client: httpx.Client, state_vector: pa.Table, opt_params:
         wd_root = enter_jma(client).work_data_root_link.navigate()
         wd_link = wd_root.upload_action.execute(UploadParameters(
             filename=f"{param_hash}.parquet",
-            binary=buffer,
+            binary=buffer.read(),
             mediatype=MediaTypes.OCTET_STREAM,
         ))
         wd_link.navigate().edit_tags_action.execute(

--- a/src/q_alchemy/initialize.py
+++ b/src/q_alchemy/initialize.py
@@ -32,8 +32,8 @@ class OptParams:
     host: str = field(default_factory=lambda: os.getenv("Q_ALCHEMY_HOST", "jobs.api.q-alchemy.com"))
     schema: str = field(default="https")
     added_headers: Dict[str, str] = field(default_factory=dict)
-    isometry_scheme: str = field(default="ccd")
-    unitary_scheme: str = field(default="qsd")
+    isometry_scheme: str = field(default="CCD")
+    unitary_scheme: str = field(default="QSD")
     job_completion_timeout_sec: int | None = field(default=300)
     basis_gates: List[str] = field(default_factory=lambda: ["u", "cx"])
     image_size: Tuple[int, int] = field(default=(-1, -1))
@@ -145,7 +145,7 @@ def create_processing_input(opt_params: OptParams) -> tuple[str, dict[str, float
                 options={
                     "isometry_scheme": opt_params.isometry_scheme,
                     "unitary_scheme": opt_params.unitary_scheme,
-                    "strategy": opt_params.extra_kwargs.get("strategy", "brute_force"),
+                    "strategy": opt_params.extra_kwargs.get("strategy", "BruteForce"),
                     "max_combination_size": opt_params.extra_kwargs.get("max_combination_size", 0),
                     "use_low_rank": opt_params.extra_kwargs.get("use_low_rank", False),
                     "initializer": opt_params.extra_kwargs.get("initializer", "BruteForceTuckerInitialize")
@@ -163,7 +163,7 @@ def create_processing_input(opt_params: OptParams) -> tuple[str, dict[str, float
                 options={
                     "isometry_scheme": opt_params.isometry_scheme,
                     "unitary_scheme": opt_params.unitary_scheme,
-                    "strategy": opt_params.extra_kwargs.get("strategy", "brute_force"),
+                    "strategy": opt_params.extra_kwargs.get("strategy", "BruteForce"),
                     "max_blocks": opt_params.extra_kwargs.get("max_blocks", 3)
                 }
             ))

--- a/src/q_alchemy/initialize.py
+++ b/src/q_alchemy/initialize.py
@@ -60,11 +60,12 @@ def create_client(opt_params: OptParams):
     return client
 
 
-def hash_state_vector(state_vector: List[complex] | np.ndarray, opt_params: OptParams):
+def hash_state_vector(buffer: io.BytesIO, opt_params: OptParams):
     if opt_params.assign_data_hash:
-        param_hash = hashlib.md5(np.asarray(state_vector).tobytes()).hexdigest()
+        param_hash = hashlib.md5(buffer.read()).hexdigest()
+        buffer.seek(0)
     else:
-        param_hash = datetime.utcnow().timestamp()
+        param_hash = datetime.now(UTC).timestamp()
     return param_hash
 
 

--- a/src/q_alchemy/initialize.py
+++ b/src/q_alchemy/initialize.py
@@ -1,13 +1,17 @@
 import hashlib
 import inspect
+import io
 import os
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, UTC
 from time import sleep
 from typing import List, Tuple, Dict
 
 import httpx
 import numpy as np
+from scipy import sparse
+import pyarrow as pa
+import pyarrow.parquet as pq
 from httpx import HTTPTransport
 from pinexq_client.core import MediaTypes
 from pinexq_client.core.hco.upload_action_hco import UploadParameters
@@ -15,6 +19,8 @@ from pinexq_client.job_management import enter_jma, Job
 from pinexq_client.job_management.hcos import WorkDataLink
 from pinexq_client.job_management.model import WorkDataQueryParameters, WorkDataFilterParameter, \
     SetTagsWorkDataParameters, JobStates
+
+from q_alchemy.pyarrow_data import convert_sparse_coo_to_arrow
 
 
 @dataclass

--- a/src/q_alchemy/pyarrow_data.py
+++ b/src/q_alchemy/pyarrow_data.py
@@ -1,0 +1,76 @@
+import json
+
+import pyarrow as pa
+from scipy.sparse import coo_array, coo_matrix
+
+
+def convert_sparse_coo_to_arrow(sparse_coo: coo_array | coo_matrix) -> pa.Table:
+    """
+    Convert a scipy sparse coo_array (complex valued) to a pyarrow Table.
+
+    Parameters:
+        sparse_coo (scipy.sparse.coo_array): The input sparse array with complex data.
+
+    Returns:
+        pyarrow.Table: A table with columns 'row', 'col', 'real', and 'imag'.
+    """
+    # Extract the row and column indices from the COO array
+    rows = sparse_coo.row
+    cols = sparse_coo.col
+
+    # Extract the data and separate the real and imaginary parts
+    data = sparse_coo.data
+    real_vals = data.real
+    imag_vals = data.imag
+
+    # Create a dictionary mapping column names to the corresponding data arrays
+    data_dict = {
+        'row': rows,
+        'col': cols,
+        'real': real_vals,
+        'imag': imag_vals
+    }
+
+    # Convert the dictionary to a PyArrow table
+    table: pa.Table = pa.Table.from_pydict(data_dict)
+
+    # Add shape information to the table metadata
+    metadata = {
+        'shape': json.dumps(sparse_coo.shape)
+    }
+
+    return table.replace_schema_metadata(metadata)
+
+
+def recover_sparse_coo_from_arrow(arrow_table: pa.Table) -> coo_matrix:
+    """
+    Recover a scipy sparse coo_array (complex valued) from a pyarrow Table.
+
+    Parameters:
+        arrow_table (pyarrow.Table): The table with columns 'row', 'col', 'real', 'imag',
+                                    and shape information in metadata.
+
+    Returns:
+        scipy.sparse.coo_array: The reconstructed sparse COO array with complex data.
+    """
+    # Convert arrow columns to numpy arrays
+    rows = arrow_table.column('row').to_numpy()
+    cols = arrow_table.column('col').to_numpy()
+    real_vals = arrow_table.column('real').to_numpy()
+    imag_vals = arrow_table.column('imag').to_numpy()
+
+    # Reconstruct complex data
+    complex_data = real_vals + 1j * imag_vals
+
+    # Get shape from metadata
+    metadata = arrow_table.schema.metadata
+    if metadata and b'shape' in metadata:
+        shape = tuple(json.loads(metadata[b'shape'].decode('utf-8')))
+        if len(shape) == 1:
+            shape = (shape[0], 1)
+    else:
+        # Fallback if metadata is not available
+        shape = (int(rows.max() + 1), int(cols.max() + 1))
+
+    # Create and return the sparse COO array with the original shape
+    return coo_matrix((complex_data, (rows, cols)), shape=shape)

--- a/tests/test_data_upload.py
+++ b/tests/test_data_upload.py
@@ -1,0 +1,68 @@
+import io
+import unittest
+
+import numpy as np
+import pyarrow.parquet as pq
+from scipy.sparse import coo_matrix
+from sklearn.datasets import fetch_openml
+
+from q_alchemy.pyarrow_data import convert_sparse_coo_to_arrow, recover_sparse_coo_from_arrow
+
+
+class TestPennyLaneIntegration(unittest.TestCase):
+
+    def setUp(self):
+        # This method will be called before each test
+        self.mnist = fetch_openml('mnist_784', version=1, parser="auto")
+
+    def tearDown(self):
+        # This method will be called after each test
+        pass
+
+    def test_data_parallel_parsing(self):
+        zeros: np.ndarray = self.mnist.data[self.mnist.target == "0"].iloc[0:10].to_numpy()
+        filler = np.empty((zeros.shape[0], 2 ** 10 - zeros.shape[1]))
+        filler.fill(0)
+
+        zeros = np.hstack([zeros, filler])
+        zeros = zeros / np.linalg.norm(zeros, axis=1).reshape(-1, 1)
+
+        zeros_sparse = coo_matrix(zeros)
+
+        zeros_table = convert_sparse_coo_to_arrow(zeros_sparse)
+
+        buffer = io.BytesIO()
+        pq.write_table(zeros_table, buffer)
+        buffer.seek(0)
+
+        table = pq.read_table(buffer)
+        zeros_sparse_recovered = recover_sparse_coo_from_arrow(table)
+
+        self.assertLessEqual(np.linalg.norm(zeros_sparse.data - zeros_sparse_recovered.data), 1e-13)
+        self.assertLessEqual(1 - abs(np.vdot(zeros_sparse.data, zeros_sparse_recovered.data))**2, 1e-13)
+
+    def test_data_single_parsing(self):
+        zeros: np.ndarray = self.mnist.data[self.mnist.target == "0"].iloc[0].to_numpy(dtype=np.complex128)
+        filler = np.empty(2 ** 10 - zeros.shape[0])
+        filler.fill(0)
+
+        zeros = np.hstack([zeros, filler])
+        zeros = zeros / np.linalg.norm(zeros)
+
+        zeros_sparse = coo_matrix(zeros).reshape(1, -1)
+        zeros_table = convert_sparse_coo_to_arrow(zeros_sparse)
+
+        buffer = io.BytesIO()
+        pq.write_table(zeros_table, buffer)
+        buffer.seek(0)
+
+        table = pq.read_table(buffer)
+        zeros_sparse_recovered = recover_sparse_coo_from_arrow(table)
+
+        self.assertLessEqual(np.linalg.norm(zeros_sparse.data - zeros_sparse_recovered.data), 1e-13)
+        self.assertLessEqual(1 - abs(np.vdot(zeros_sparse.data, zeros_sparse_recovered.data))**2, 1e-13)
+
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Uploading data as sparse using pyarrow and parquet makes it faster and easier to upload data. 
Furthermore, the lookup of processing step's version is now done correctly.