### PR TITLE
Enable batched execution for Q-Alchemy integration with PennyLane

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,9 +173,8 @@ def circuit(x):
     return qml.expval(qml.PauliZ(0))
 
 # Run the circuit on a batch of inputs
-X_tensor = torch.tensor(X, dtype=torch.float32)
-results = torch.stack([circuit(x) for x in X_tensor])
-print(results)
+X_tensor = torch.tensor(X, dtype=torch.float64)
+print(qml.draw(circuit, level="device", max_length=100)(X_tensor))
 ```
 
 This example demonstrates how batched data can be processed using broadcasting with `AmplitudeEmbedding`, and how Q-Alchemy is triggered on simulators like `qiskit.aer`. When moving to real hardware or gate-based backends that lack `StatePrep` gate, Q-Alchemy will transparently handle the state preparation.

--- a/README.md
+++ b/README.md
@@ -165,7 +165,6 @@ def circuit(x):
     AmplitudeEmbedding(
         x,
         wires=[0],
-        use_research_function="baa_tucker_initialize",
         opt_params=OptParams(
             max_fidelity_loss=0.0,
             api_key="<your api key>"

--- a/README.md
+++ b/README.md
@@ -137,6 +137,50 @@ def circuit(state=None):
 print(qml.draw(circuit, level="device", max_length=100)(zero.tolist()))
 ```
 
+### Broadcasting with PennyLane
+
+PennyLane provides native support for *broadcasting*, which allows quantum nodes to process batches of inputs efficiently. This is particularly useful in machine learning applications where inputs often come in batches. When broadcasting is used in conjunction with Q-Alchemy, each state in the batch is individually prepared using Q-Alchemy's circuit synthesis capabilities.
+
+> ⚠️ **Note:** For simulators or backends that support native state initialization using the `StatePrep` gate—such as `default.qubit`, and `lightning.qubit`—the state vector is injected directly without any decomposition into quantum gates. In this case, Q-Alchemy is not used. This behavior is ideal for rapid prototyping and testing. Switching to a hardware backend (or one without native state prep) will automatically invoke Q-Alchemy for state preparation.
+
+#### Broadcasting Example with `qiskit.aer`
+
+```python
+import numpy as np
+import pennylane as qml
+import torch
+
+from q_alchemy.pennylane_integration import AmplitudeEmbedding, OptParams
+from sklearn.datasets import make_moons
+
+# Sample data
+X, _ = make_moons(n_samples=5, noise=0.1)
+X = X / np.linalg.norm(X, axis=1, keepdims=True)  # Normalize each row for amplitude embedding
+
+# Create PennyLane device
+dev = qml.device("qiskit.aer", wires=1)
+
+@qml.qnode(dev, interface="torch")
+def circuit(x):
+    AmplitudeEmbedding(
+        x,
+        wires=[0],
+        use_research_function="baa_tucker_initialize",
+        opt_params=OptParams(
+            max_fidelity_loss=0.0,
+            api_key="<your api key>"
+        )
+    )
+    return qml.expval(qml.PauliZ(0))
+
+# Run the circuit on a batch of inputs
+X_tensor = torch.tensor(X, dtype=torch.float32)
+results = torch.stack([circuit(x) for x in X_tensor])
+print(results)
+```
+
+This example demonstrates how batched data can be processed using broadcasting with `AmplitudeEmbedding`, and how Q-Alchemy is triggered on simulators like `qiskit.aer`. When moving to real hardware or gate-based backends that lack `StatePrep` gate, Q-Alchemy will transparently handle the state preparation.
+
 ### Developer UI
 
 You can play around with this as you please and check out the [Hypermedia-Test-UI](https://hypermedia-ui-demo.q-alchemy.com/hui?apiPath=https%3A%2F%2Fjobs.api.q-alchemy.com%2Fapi%2FEntryPoint)

--- a/examples/broadcasting_example.ipynb
+++ b/examples/broadcasting_example.ipynb
@@ -26,7 +26,6 @@
     "    AmplitudeEmbedding(\n",
     "        x,\n",
     "        wires=[0],\n",
-    "        use_research_function=\"baa_tucker_initialize\",\n",
     "        opt_params=OptParams(\n",
     "            max_fidelity_loss=0.0,\n",
     "            basis_gates=[\"id\", \"rx\", \"ry\", \"rz\", \"cx\"],\n",

--- a/examples/broadcasting_example.ipynb
+++ b/examples/broadcasting_example.ipynb
@@ -28,16 +28,14 @@
     "        wires=[0],\n",
     "        opt_params=OptParams(\n",
     "            max_fidelity_loss=0.0,\n",
-    "            basis_gates=[\"id\", \"rx\", \"ry\", \"rz\", \"cx\"],\n",
     "            api_key=\"<your api key>\"\n",
     "        )\n",
     "    )\n",
     "    return qml.expval(qml.PauliZ(0))\n",
     "\n",
     "# Run the circuit on a batch of inputs\n",
-    "X_tensor = torch.tensor(X, dtype=torch.float32)\n",
-    "results = torch.stack([circuit(x) for x in X_tensor])\n",
-    "print(results)"
+    "X_tensor = torch.tensor(X, dtype=torch.float64)\n",
+    "print(qml.draw(circuit, level=\"device\", max_length=100)(X_tensor))"
    ]
   }
  ],

--- a/examples/broadcasting_example.ipynb
+++ b/examples/broadcasting_example.ipynb
@@ -1,0 +1,66 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8b05dae0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import pennylane as qml\n",
+    "import torch\n",
+    "\n",
+    "from q_alchemy.pennylane_integration import AmplitudeEmbedding, OptParams\n",
+    "from sklearn.datasets import make_moons\n",
+    "\n",
+    "# Sample data\n",
+    "X, _ = make_moons(n_samples=5, noise=0.1)\n",
+    "X = X / np.linalg.norm(X, axis=1, keepdims=True)  # Normalize each row for amplitude embedding\n",
+    "\n",
+    "# Create PennyLane device\n",
+    "dev = qml.device(\"qiskit.aer\", wires=1)\n",
+    "\n",
+    "@qml.qnode(dev, interface=\"torch\")\n",
+    "def circuit(x):\n",
+    "    AmplitudeEmbedding(\n",
+    "        x,\n",
+    "        wires=[0],\n",
+    "        use_research_function=\"baa_tucker_initialize\",\n",
+    "        opt_params=OptParams(\n",
+    "            max_fidelity_loss=0.0,\n",
+    "            basis_gates=[\"id\", \"rx\", \"ry\", \"rz\", \"cx\"],\n",
+    "            api_key=\"<your api key>\"\n",
+    "        )\n",
+    "    )\n",
+    "    return qml.expval(qml.PauliZ(0))\n",
+    "\n",
+    "# Run the circuit on a batch of inputs\n",
+    "X_tensor = torch.tensor(X, dtype=torch.float32)\n",
+    "results = torch.stack([circuit(x) for x in X_tensor])\n",
+    "print(results)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "qasdk",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/broadcasting_example.ipynb
+++ b/examples/broadcasting_example.ipynb
@@ -5,7 +5,23 @@
    "execution_count": null,
    "id": "8b05dae0",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0: ──U3(0.69,0.00,0.00)──U3(0.00,0.00,3.14)─┤  <Z>\n",
+      "\n",
+      "0: ──U3(0.05,0.00,0.00)──U3(0.00,0.00,3.14)─┤  <Z>\n",
+      "\n",
+      "0: ──U3(3.08,0.00,0.00)──U3(0.00,0.00,-3.14)─┤  <Z>\n",
+      "\n",
+      "0: ──U3(0.06,0.00,0.00)─┤  <Z>\n",
+      "\n",
+      "0: ──U3(0.54,0.00,0.00)─┤  <Z>\n"
+     ]
+    }
+   ],
    "source": [
     "import numpy as np\n",
     "import pennylane as qml\n",

--- a/src/q_alchemy/pennylane_integration.py
+++ b/src/q_alchemy/pennylane_integration.py
@@ -1,7 +1,5 @@
 from typing import Optional, Union
 
-import logging
-
 from scipy.sparse import csr_matrix
 
 import pennylane as qml

--- a/src/q_alchemy/pennylane_integration.py
+++ b/src/q_alchemy/pennylane_integration.py
@@ -14,14 +14,18 @@ from typing import Optional, Union
 from scipy.sparse import csr_matrix
 
 import pennylane as qml
+import numpy as np
+from pennylane import math
 from pennylane.ops.qubit.state_preparation import StatePrep
 from pennylane.operation import Operation, Operator
 from pennylane.typing import TensorLike
-from pennylane.wires import WiresLike
+from pennylane.wires import Wires, WiresLike
 
 from q_alchemy.initialize import q_alchemy_as_qasm, OptParams
 
-LOG = logging.getLogger(__name__)
+# Normalization precision required for compatibility with Qiskit and qclib state preparation.
+ATOL = 1e-10
+RTOL = 1e-9
 
 class AmplitudeEmbedding(StatePrep):
     # pylint: disable=too-many-arguments,too-many-positional-arguments
@@ -76,8 +80,85 @@ class AmplitudeEmbedding(StatePrep):
         [QAlchemyStatePreparation(tensor([1, 0, 0, 0], requires_grad=True), wires=[0, 1])]
 
         """
-
         return [QAlchemyStatePreparation(state, wires, id=None, **kwargs)]
+
+    @staticmethod
+    def _preprocess(state, wires, pad_with, normalize, validate_norm):
+        """Validate and pre-process inputs as follows:
+
+        * If state is batched, the processing that follows is applied to each state set in the batch.
+        * Check that the state tensor is one-dimensional.
+        * If pad_with is None, check that the last dimension of the state tensor
+          has length :math:`2^n` where :math:`n` is the number of qubits. Else check that the
+          last dimension of the state tensor is not larger than :math:`2^n` and pad state
+          with value if necessary.
+        * If normalize is false, check that last dimension of state is normalised to one. Else, normalise the
+          state tensor.
+        """
+        if isinstance(state, (list, tuple)):
+            state = math.array(state)
+
+        # Promote from `float32` to `float64` to ensure normalization meets the required precision.
+        if "float32" in str(state.dtype):
+            state = state.astype(np.float64, copy=False)
+        if "complex64" in str(state.dtype):
+            state = state.astype(np.complex128, copy=False)
+
+        shape = math.shape(state)
+
+        # check shape
+        if len(shape) not in (1, 2):
+            raise ValueError(
+                f"State must be a one-dimensional tensor, or two-dimensional with batching; got shape {shape}."
+            )
+
+        n_states = shape[-1]
+        dim = 2 ** len(Wires(wires))
+        if pad_with is None and n_states != dim:
+            raise ValueError(
+                f"State must be of length {dim}; got length {n_states}. "
+                f"Use the 'pad_with' argument for automated padding."
+            )
+
+        if pad_with is not None:
+            normalize = True
+            if n_states > dim:
+                raise ValueError(
+                    f"Input state must be of length {dim} or "
+                    f"smaller to be padded; got length {n_states}."
+                )
+
+            # pad
+            if n_states < dim:
+                padding = [pad_with] * (dim - n_states)
+                if len(shape) > 1:
+                    padding = [padding] * shape[0]
+                padding = math.convert_like(padding, state)
+                state = math.hstack([state, padding])
+
+        if not validate_norm:
+            return state
+
+        # normalize
+        if "int" in str(state.dtype):
+            state = math.cast_like(state, 0.0)
+
+        norm = math.linalg.norm(state, axis=-1)
+
+        if math.is_abstract(norm):
+            if normalize:
+                state = state / math.reshape(norm, (*shape[:-1], 1))
+
+        elif not math.allclose(norm, 1.0, atol=ATOL, rtol=RTOL):
+            if normalize:
+                state = state / math.reshape(norm, (*shape[:-1], 1))
+            else:
+                raise ValueError(
+                    f"The state must be a vector of norm 1.0; got norm {norm}. "
+                    "Use 'normalize=True' to automatically normalize."
+                )
+
+        return state
 
 class QAlchemyStatePreparation(Operation):
     def __init__(self, state_vector, wires, id=None, **kwargs):
@@ -115,7 +196,7 @@ class QAlchemyStatePreparation(Operation):
 
             if not qml.math.is_abstract(state):
                 norm = qml.math.sum(qml.math.abs(state) ** 2)
-                if not qml.math.allclose(norm, 1.0, atol=1e-3):
+                if not qml.math.allclose(norm, 1.0, atol=ATOL, rtol=RTOL):
                     raise ValueError(
                         f"State vectors have to be of norm 1.0, vector {i} has norm {norm}"
                     )

--- a/src/q_alchemy/pennylane_integration.py
+++ b/src/q_alchemy/pennylane_integration.py
@@ -1,3 +1,14 @@
+# Copyright 2022-2023 data cybernetics ssc GmbH.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 from typing import Optional, Union
 
 from scipy.sparse import csr_matrix

--- a/src/q_alchemy/pennylane_integration.py
+++ b/src/q_alchemy/pennylane_integration.py
@@ -86,8 +86,6 @@ class QAlchemyStatePreparation(Operation):
         if "opt_params" in kwargs:
             opt_params = kwargs["opt_params"]
         else:
-            if "basis_gates" in kwargs:
-                raise Warning("Basis Gates cannot be set currently. The input will be ignored.")
             opt_params = OptParams.from_dict(kwargs)
 
         # Append options

--- a/src/q_alchemy/qiskit_integration.py
+++ b/src/q_alchemy/qiskit_integration.py
@@ -11,7 +11,6 @@
 # limitations under the License.
 import datetime
 import hashlib
-import logging
 from typing import List
 
 import numpy as np
@@ -20,10 +19,6 @@ from qiskit.circuit.instruction import Instruction
 from qiskit.quantum_info.states.statevector import Statevector
 
 from q_alchemy.initialize import q_alchemy_as_qasm, create_client, OptParams
-
-logging.getLogger("httpx").setLevel(logging.WARN)
-LOG = logging.getLogger(__name__)
-
 
 class QAlchemyInitialize(Instruction):
     """


### PR DESCRIPTION
**Summary**

This PR adds native support for batched inputs with the `AmplitudeEmbedding` class, enabling seamless integration of Q-Alchemy state preparation with PennyLane and PyTorch workflows such as `qml.qnn.TorchLayer`.

With this update, `AmplitudeEmbedding` now handles input batches directly and decomposes each into a corresponding `QAlchemyStatePreparation` operation. No additional transforms such as `qml.broadcast_expand` are required.

**Details**

- Enhanced `AmplitudeEmbedding`:
  - Accepts batched state vectors of shape `(batch_size, 2**n)`
  - Internally decomposes each vector into a `QAlchemyStatePreparation` call
  - Fully compatible with `qml.qnn.TorchLayer`
  - Automatically validates norm and shape per instance

- No `qml.broadcast` needed:
  - User code remains simple and torch-native
  - The same interface as PennyLane's standard `AmplitudeEmbedding` is maintained

**Related Issue**

Fixes: [#26](https://github.com/data-cybernetics/q-alchemy-sdk-py/issues/26) (QAlchemy does not support broadcasting)

This enhancement addresses the issue where attempts to use `QAlchemyStatePreparation` with batched data (e.g., from a Torch `DataLoader`) would raise:
```
ValueError: Broadcasting with QAlchemyStatePreparation is not supported. Please use the qml.transforms.broadcast_expand transform to use broadcasting with QAlchemyStatePreparation.
```
