### PR TITLE
Retrieve and fix the (newly available) global phase for both Qiskit and Pennylane integration.

### DIFF
--- a/src/q_alchemy/pennylane_integration.py
+++ b/src/q_alchemy/pennylane_integration.py
@@ -221,8 +221,9 @@ class QAlchemyStatePreparation(Operation):
                 "QAlchemyStatePreparation."
             )
 
-        qasm = q_alchemy_as_qasm(state_vector, opt_params)
+        qasm, summary = q_alchemy_as_qasm(state_vector, opt_params, return_summary=True)
         loaded_circuit = qml.from_qasm(qasm)
         # Reorder the wires, as the original qasm code assumes qubit 0 is the least significant bit.
         qs = qml.tape.make_qscript(loaded_circuit)(wires=wires[::-1])
-        return qs.operations
+        # Add explicit globalphase to the start.
+        return [qml.GlobalPhase(-summary["global_phase"])] + qs.operations

--- a/src/q_alchemy/qiskit_integration.py
+++ b/src/q_alchemy/qiskit_integration.py
@@ -76,6 +76,7 @@ class QAlchemyInitialize(Instruction):
             self.param_hash = datetime.datetime.utcnow().timestamp()
 
     def _define(self):
-        qasm = q_alchemy_as_qasm(self.params, self.opt_params, self.client)
+        qasm, summary = q_alchemy_as_qasm(self.params, self.opt_params, self.client, return_summary=True)
         qc = QuantumCircuit.from_qasm_str(qasm)
+        qc.global_phase = summary["global_phase"]
         self.definition = qc

--- a/tests/test_pennylane_integration.py
+++ b/tests/test_pennylane_integration.py
@@ -43,8 +43,8 @@ class TestPennyLaneIntegration(unittest.TestCase):
 
         state_pennylane = circuit_pennylane(state_qiskit)
 
-        #self.assertLessEqual(np.linalg.norm(state_qiskit - state_pennylane), 1e-13) #phase
         self.assertLessEqual(1 - abs(np.vdot(state_qiskit, state_pennylane))**2, 1e-13)
+        self.assertLessEqual(np.linalg.norm(state_qiskit - state_pennylane), 1e-12) #phase
 
 
     def test_rnd_real(self):
@@ -68,8 +68,8 @@ class TestPennyLaneIntegration(unittest.TestCase):
 
         state_pennylane = circuit_pennylane(state_vector)
 
-        #self.assertLessEqual(np.linalg.norm(state_vector - state_pennylane), 1e-13) #phase
         self.assertLessEqual(1 - abs(np.vdot(state_vector, state_pennylane))**2, 1e-13)
+        self.assertLessEqual(np.linalg.norm(state_vector - state_pennylane), 1e-12) #phase
 
     def test_rnd_complex(self):
 
@@ -92,8 +92,8 @@ class TestPennyLaneIntegration(unittest.TestCase):
 
         state_pennylane = circuit_pennylane(state_vector)
 
-        #self.assertLessEqual(np.linalg.norm(state_vector - state_pennylane), 1e-13) #phase
         self.assertLessEqual(1 - abs(np.vdot(state_vector, state_pennylane))**2, 1e-13)
+        self.assertLessEqual(np.linalg.norm(state_vector - state_pennylane), 1e-12) #phase
 
 
 if __name__ == '__main__':

--- a/tests/test_qiskit_integration.py
+++ b/tests/test_qiskit_integration.py
@@ -1,3 +1,4 @@
+import math
 import unittest
 
 import numpy as np
@@ -25,7 +26,7 @@ class TestQiskitIntegration(unittest.TestCase):
             qasm = f.read()
 
         qc = QuantumCircuit.from_qasm_str(qasm)
-        state_vector = Statevector(qc).data
+        state_vector = Statevector(qc)
 
         opt_params = OptParams(
         #        api_key=os.environ["Q_ALCHEMY_API_KEY"]
@@ -35,14 +36,11 @@ class TestQiskitIntegration(unittest.TestCase):
             params=state_vector,
             opt_params=opt_params
         )
-        circuit_qiskit = instr.definition
 
-        state_qiskit = Statevector(circuit_qiskit).data
+        state_qiskit = Statevector(instr)
 
-
-        #self.assertLessEqual(np.linalg.norm(state_vector - state_qiskit), 1e-13) # phase mismatch?
-        print(np.vdot(state_vector, state_qiskit))
         self.assertLessEqual(1 - abs(np.vdot(state_vector, state_qiskit))**2, 1e-13)
+        self.assertLessEqual(np.linalg.norm(state_vector - state_qiskit), 1e-12) # not quite that precise?
 
 
     def test_rnd_real(self):
@@ -61,9 +59,8 @@ class TestQiskitIntegration(unittest.TestCase):
 
         state_qiskit = Statevector(circuit_qiskit).data
 
-        #self.assertLessEqual(np.linalg.norm(state_vector - state_qiskit), 1e-13) # phase mismatch?
-        print(np.vdot(state_vector, state_qiskit))
         self.assertLessEqual(1 - abs(np.vdot(state_vector, state_qiskit))**2, 1e-13)
+        self.assertLessEqual(np.linalg.norm(state_vector - state_qiskit), 1e-12) # not quite that precise?
 
     def test_rnd_complex(self):
 
@@ -81,9 +78,8 @@ class TestQiskitIntegration(unittest.TestCase):
 
         state_qiskit = Statevector(circuit_qiskit).data
 
-        #self.assertLessEqual(np.linalg.norm(state_vector - state_qiskit), 1e-13) # phase mismatch?
-        print(np.vdot(state_vector, state_qiskit))
         self.assertLessEqual(1 - abs(np.vdot(state_vector, state_qiskit))**2, 1e-13)
+        self.assertLessEqual(np.linalg.norm(state_vector - state_qiskit), 1e-12) # not quite that precise?
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
QASM2 cannot record global phase, so we need to get that (newly added) information from the Summary instead.