### PR TITLE
Fix imports breaking if user did not install all optionals

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dev = [
     "notebook>=7.4.5",
     "pip>=25.2",
     "scipy-stubs>=1.16.1.1",
+    "qiskit[qasm3-import]"
 ]
 
 [project.optional-dependencies]

--- a/src/q_alchemy/__init__.py
+++ b/src/q_alchemy/__init__.py
@@ -1,3 +1,9 @@
 from .initialize import q_alchemy_as_qasm
-from .qiskit_integration import QAlchemyInitialize
-from .pennylane_integration import QAlchemyStatePreparation
+try: # should fail silently if user has not installed optional dependencies
+    from .qiskit_integration import QAlchemyInitialize
+except ImportError:
+    pass
+try:
+    from .pennylane_integration import QAlchemyStatePreparation
+except ImportError:
+    pass


### PR DESCRIPTION
Previously, importing q_alchemy would fail if the user did not install pennylane, because `q_alchemy.__init__` imported from pennylane_integration, which requires pennylane.

This was awkward for a few reasons, including that pennylane requires Qiskit <= 1.2.