### PR TITLE
Add PyPI publishing via GitHub Actions + Trusted Publishing

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,64 @@
+name: Publish to PyPI
+
+# Publishes q-alchemy-sdk-py to PyPI via Trusted Publishing (OIDC) — no API
+# tokens or secrets involved. One-time setup required on pypi.org:
+#   project "q-alchemy-sdk-py" -> Manage -> Publishing -> Add a new publisher:
+#     owner: data-cybernetics, repository: q-alchemy-sdk-py,
+#     workflow: publish.yaml, environment: pypi
+# and on GitHub: Settings -> Environments -> create "pypi" (optionally with
+# required reviewers as a release gate).
+#
+# Release process:
+#   1. bump [project].version in pyproject.toml, merge to main
+#   2. create a GitHub Release with tag v<version> (e.g. v0.2.28)
+#   3. this workflow builds, verifies tag == package version, and publishes
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:  # manual fallback: builds and publishes the current main
+
+jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+      - name: Build sdist + wheel
+        run: uv build
+      - name: Check tag matches package version
+        if: github.event_name == 'release'
+        run: |
+          PKG_VERSION=$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          TAG="${{ github.event.release.tag_name }}"
+          if [ "v${PKG_VERSION}" != "${TAG}" ] && [ "${PKG_VERSION}" != "${TAG}" ]; then
+            echo "::error::Release tag '${TAG}' does not match pyproject version '${PKG_VERSION}'"
+            exit 1
+          fi
+      - name: Smoke-check the wheel
+        run: |
+          python3 -m venv /tmp/smoke && /tmp/smoke/bin/pip -q install dist/*.whl
+          /tmp/smoke/bin/python -c "import q_alchemy; from q_alchemy.initialize import OptParams; print('import OK,', OptParams().host)"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: pypi
+      url: https://pypi.org/p/q-alchemy-sdk-py
+    permissions:
+      id-token: write  # required for PyPI Trusted Publishing (OIDC)
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - name: Publish
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,35 @@
+# Releasing q-alchemy-sdk-py
+
+Publishing to [PyPI](https://pypi.org/project/q-alchemy-sdk-py/) is automated via
+GitHub Actions and [Trusted Publishing](https://docs.pypi.org/trusted-publishers/)
+(OIDC) — there are no API tokens to manage or rotate.
+
+## One-time setup (already done? check before repeating)
+
+1. **PyPI** — as an owner of the `q-alchemy-sdk-py` project: *Manage → Publishing →
+   Add a new publisher* with
+   - Owner: `data-cybernetics`
+   - Repository: `q-alchemy-sdk-py`
+   - Workflow name: `publish.yaml`
+   - Environment name: `pypi`
+2. **GitHub** — *Settings → Environments → New environment* named `pypi`.
+   Optionally add *required reviewers* there: publishing then pauses for an
+   explicit approval click, mirroring the manual-gate policy used on the
+   internal Gitea pipelines.
+
+## Release process
+
+1. Bump `[project].version` in `pyproject.toml` (PR, review, merge to `main`).
+2. Create a **GitHub Release** with tag `v<version>` (e.g. `v0.2.28`) on `main`.
+3. The `Publish to PyPI` workflow builds sdist + wheel, verifies the tag matches
+   the package version, smoke-imports the wheel, and publishes.
+
+Notes:
+
+- A tag/version mismatch fails the build step on purpose — fix the tag or the
+  version, never force.
+- PyPI rejects re-uploads of an existing version; a botched release needs a new
+  patch version (yank the bad one on PyPI if necessary).
+- The integration tests are *live-service* tests requiring `Q_ALCHEMY_API_KEY`
+  and are intentionally not part of the publish workflow — run them before
+  merging release PRs.


### PR DESCRIPTION
publish.yaml: on GitHub Release (or manual dispatch) build sdist+wheel with uv, verify the release tag matches the pyproject version, smoke-import the wheel, then publish through pypa/gh-action-pypi-publish using OIDC Trusted Publishing (id-token: write, environment "pypi") -- no long-lived API tokens. RELEASING.md documents the one-time PyPI + GitHub environment setup and the release process.


Claude-Session: https://claude.ai/code/session_01XrEoFCzhjPhu2EsycaJhxd