### PR TITLE
Declare numpy and scipy as runtime dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,6 @@ distribution = true
 
 [tool.pdm.build]
 includes = [
-    "src/hypermedia_client",
     "src/q_alchemy",
 ]
 
@@ -26,6 +25,8 @@ dependencies = [
     "httpx<1.0.0,>=0.25.0",
     "tenacity>=8.2.3",
     "pinexq-client>=1.3.0",
+    "numpy>=1.26",
+    "scipy>=1.11",
     "tqdm",
     "pyarrow>=19.0.1",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -11,7 +11,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-28T16:10:13.9075644Z"
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
@@ -2826,9 +2826,11 @@ version = "0.2.27"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },
+    { name = "numpy" },
     { name = "pinexq-client" },
     { name = "pyarrow" },
     { name = "pydantic" },
+    { name = "scipy" },
     { name = "tenacity" },
     { name = "tqdm" },
 ]
@@ -2877,6 +2879,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.25.0,<1.0.0" },
     { name = "jupyter", marker = "extra == 'examples'" },
     { name = "matplotlib", marker = "extra == 'examples'" },
+    { name = "numpy", specifier = ">=1.26" },
     { name = "openqasm3", extras = ["parser"], marker = "extra == 'pennylane'" },
     { name = "pandas", marker = "extra == 'examples'" },
     { name = "pennylane", marker = "extra == 'examples'", specifier = ">=0.42.0" },
@@ -2895,6 +2898,7 @@ requires-dist = [
     { name = "qiskit-ibm-runtime", marker = "extra == 'examples'", specifier = ">=0.45.1" },
     { name = "qutip", marker = "extra == 'examples'" },
     { name = "scikit-learn", marker = "extra == 'examples'" },
+    { name = "scipy", specifier = ">=1.11" },
     { name = "tenacity", specifier = ">=8.2.3" },
     { name = "torch", marker = "extra == 'examples'", specifier = ">=2.11.0" },
     { name = "tqdm" },


### PR DESCRIPTION
q_alchemy.initialize imports numpy and scipy at module level, but neither was declared — installs only worked because older pyarrow pulled numpy in transitively (dropped in recent pyarrow) and scipy arrived via dev/extra environments. Caught by the publish workflow's wheel smoke test: a bare `pip install q_alchemy_sdk_py-*.whl` failed with ModuleNotFoundError: numpy.

Also drops the stale src/hypermedia_client build include (the directory no longer exists; wheels only ever shipped q_alchemy).


Claude-Session: https://claude.ai/code/session_01XrEoFCzhjPhu2EsycaJhxd