### PR TITLE
Fix misleading error when a processing step is not found

### DIFF
--- a/src/q_alchemy/initialize.py
+++ b/src/q_alchemy/initialize.py
@@ -262,11 +262,15 @@ def from_name(
 
     # Check if at least one result is found
     if len(query_result.processing_steps) == 0:
-        # Attempt to suggest alternative steps if exact match not found
-        suggested_steps = ProcessingStep._processing_steps_by_name(client, step_name)
+        # NOTE: no suggestion lookup here — the private helper this used to
+        # call (ProcessingStep._processing_steps_by_name) no longer exists in
+        # pinexq-client >= 9.7, which turned this error path into a confusing
+        # AttributeError that masked the actual problem.
+        version_part = f" (version {version})" if version else ""
         raise NameError(
-            f"No processing step with the name {step_name} and version {version} registered. "
-            f"Suggestions: {suggested_steps}"
+            f"No processing step named '{step_name}'{version_part} is registered "
+            f"or visible to this account on {client.base_url}. If the step was "
+            f"deployed recently, it may not have been set public yet."
         )
 
     sorted(query_result.processing_steps, key=lambda x: x.version, reverse=True)


### PR DESCRIPTION
The zero-results path in from_name() called
ProcessingStep._processing_steps_by_name, a private pinexq-client helper that no longer exists in >= 9.7 — so users got "AttributeError: type object 'ProcessingStep' has no attribute '_processing_steps_by_name'" instead of the actual problem. Raise a clear NameError naming the step, version and endpoint, with a hint at the most common cause since the 2026-08 platform version: the step was deployed but not yet set public.


Claude-Session: https://claude.ai/code/session_01XrEoFCzhjPhu2EsycaJhxd